### PR TITLE
Fix unresolved image and markdown hyperlink urls

### DIFF
--- a/docs/theory/decentralized-trust-network.md
+++ b/docs/theory/decentralized-trust-network.md
@@ -1,18 +1,18 @@
 # Decentralized Trust Network
 
-The secure sharing of [secrets](./Glossary.md#secret) between people and machines involves authenticating [digital identities](./Glossary.md#identity), deciding whether to trust those digital identities, and authorising the privilege of accessing the secrets.
+The secure sharing of [secrets](./glossary.md#secret) between people and machines involves authenticating [digital identities](./glossary.md#identity), deciding whether to trust those digital identities, and authorising the privilege of accessing the secrets.
 
 Authentication involves securely identifying an agent (person or machine) on the internet with whom we wish to share secret information. Without this, regardless of what encryption technology we use and how we use it, any secret shared would be compromised.
 
 ## Digital Identities and Identity Providers
 
-To authenticate [digital identities](./Glossary.md#digital-identity), we must understand that they are digital artifacts (e.g. social media profiles, public keys, certificates) that exist on the internet and represent real-world [agents](./Glossary.md#agent). If multiple digital identities are used to represent a single agent, then each digital identity is a facet or [point of presence](./Glossary.md#point-of-presence) of the combined identity.
+To authenticate [digital identities](./glossary.md#digital-identity), we must understand that they are digital artifacts (e.g. social media profiles, public keys, certificates) that exist on the internet and represent real-world [agents](./glossary.md#agent). If multiple digital identities are used to represent a single agent, then each digital identity is a facet or [point of presence](./glossary.md#point-of-presence) of the combined identity.
 
 The most commonly used digital identities are hosted on centralized identity provider platforms. There are public (e.g. StackOverflow, GitHub, eBay, Facebook, LinkedIn, Twitter) and private platforms (e.g. Active Directory, Slack).
 
 <p align="center">
   <figure>
-    <img src="images/gestalts-and-DIs/di-ceos.png" width="60%" />
+    <img src="/images/gestalts-and-DIs/di-ceos.png" width="60%" />
     <br />
     <figcaption>From top left to bottom: Digital identities for the CEOs of Twitter, GitHub, LinkedIn, and FaceBook</figcaption>
   </figure>
@@ -48,16 +48,16 @@ Polykey's trust network architecture is composed of several components.
 
 ### Keynode Sigchain
 
-Polykey's secrets are stored in [Vaults](./Glossary.md#vault) that are managed and shared between [Keynodes](./Glossary.md#keynode). Each Keynode possesses a digital identity in Polykey's trust network. These identities start with root public & private key pair and along with other information is put together into a [X.509 certificate](https://en.wikipedia.org/wiki/X.509).
+Polykey's secrets are stored in [Vaults](./glossary.md#vault) that are managed and shared between [Keynodes](./glossary.md#keynode). Each Keynode possesses a digital identity in Polykey's trust network. These identities start with root public & private key pair and along with other information is put together into a [X.509 certificate](https://en.wikipedia.org/wiki/X.509).
 
 * The Keynode Identity Certificate provides information about its public key, as well as the owner of this public key.
 * The key owner, as well as other entities (represented by their own X.509 certificates) can sign claims held on the Keynode Identity Certificate to verify their authenticity.
-* This chain of signed claims (known as a [Sigchain](./Glossary.md#sigchain)) allows for the maintenance of a [chain of trust](https://en.wikipedia.org/wiki/Chain_of_trust), serving as an append-only log of signed actions and claims made by the Keynode.
+* This chain of signed claims (known as a [Sigchain](./glossary.md#sigchain)) allows for the maintenance of a [chain of trust](https://en.wikipedia.org/wiki/Chain_of_trust), serving as an append-only log of signed actions and claims made by the Keynode.
 * The Keynode's [root certificate](https://en.wikipedia.org/wiki/Root_certificate) acts as a [trust anchor](https://en.wikipedia.org/wiki/Trust_anchor), establishing trust for the entire Sigchain and allowing claims to hold an assumed level of trust, provided you trust the Keynode.
 
 <p align="center">
   <figure>
-    <img src="images/gestalts-and-DIs/X509.png" width="90%" />
+    <img src="images/divio_quadrant.png" width="100%" />
     <br />
     <figcaption>X.509 certificates act as the root of trust for Polykey Sigchains</figcaption>
   </figure>
@@ -67,12 +67,12 @@ These Keynodes are at the core of Polykey's system of authentication, which is m
 
 ### Gestalt Graph
 
-Within Polykey, a [Gestalt](./Glossary.md#gestalt) refers to the representation of an agent. The name comes from the field of [Gestaltism](https://en.wikipedia.org/wiki/Gestalt_psychology), which is based on the idea that "the whole is greater than the sum of its parts". For our purposes, the "whole" here refers to an agent, and the "sum of its parts" refers both to digital identities and to secrets.
+Within Polykey, a [Gestalt](./glossary.md#gestalt) refers to the representation of an agent. The name comes from the field of [Gestaltism](https://en.wikipedia.org/wiki/Gestalt_psychology), which is based on the idea that "the whole is greater than the sum of its parts". For our purposes, the "whole" here refers to an agent, and the "sum of its parts" refers both to digital identities and to secrets.
 
 Our Gestalts are comprised of the following set of components:
 - At least one Keynode
 - Zero or more digital identities
-- Node-to-Node and Node-to-Identity [cryptolinks](./Glossary.md#cryptolink)
+- Node-to-Node and Node-to-Identity [cryptolinks](./glossary.md#cryptolink)
 
 Keynodes store secrets, digital identities are artifacts of the agent's identity, and cryptolinks are what join these components together. These cryptolinks are simply signed statements on Keynode Sigchains and digital identities, however, they can be visualized as the edges of a graph with Keynodes and digital identities as its vertices.
 
@@ -86,8 +86,8 @@ Keynodes store secrets, digital identities are artifacts of the agent's identity
 
 These cryptolink claims are statements of ownership:
 - Node-to-Node claims consist of a doubly-signed statement on each of two Keynodes (with each of these signed by both Keynodes) and indicate that the two Keynodes are members of the same Gestalt.
-- Node-to-Identity claims consist of a singly-signed statement on one Keynode claiming ownership over a particular digital identity, as well as a similar singly-signed statement (signed by the Keynode) on the digital identity (made by itself). This process is known as digital identity [augmentation](./Glossary.md#augmentation).
-- Claims are ordered and are immutable once created, ensuring both their [authenticity](./Glossary.md#authenticity) and [integrity](./Glossary.md#integrity), and preventing the insertion of false claims into the Sigchain.
+- Node-to-Identity claims consist of a singly-signed statement on one Keynode claiming ownership over a particular digital identity, as well as a similar singly-signed statement (signed by the Keynode) on the digital identity (made by itself). This process is known as digital identity [augmentation](./glossary.md#augmentation).
+- Claims are ordered and are immutable once created, ensuring both their [authenticity](./glossary.md#authenticity) and [integrity](./glossary.md#integrity), and preventing the insertion of false claims into the Sigchain.
 - A single Keynode can augment multiple digital identities, as well as make claims over other Keynodes, leading to the formation of a Gestalt that is comprised of all of the Keynodes and digital identities that represent a particular agent.
 
 ### Identity Augmentation Process
@@ -106,7 +106,7 @@ The process of digital identity augmentation within Polykey involves four main s
 1. Authorization: Before a digital identity can be augmented, Polykey needs permission to access, and make changes to, the digital identity through its provider. We utilize [OAuth](https://auth0.com/docs/authorization/flows/device-authorization-flow) for this process, allowing only secure, delegated access to user data.
 2. Updating access permissions: The first step of the augmentation process itself is to update Keynode and Gestalt permissions. This step links the Keynode and digital identity inside the user's Gestalt and updates (or creates) Keynode permissions in the ACL to reflect these changes (see [Sharing](Gestalts-and-Digital-Identities#sharing) below for an explanation of the ACL).
 3. Generating a claim on the Sigchain: A cryptolink claim between a Keynode and digital identity begins on the Keynode. The claim is generated by providing the name of both the digital identity and its provider to the Keynode, which then constructs and appends the claim to its Sigchain. This claim can subsequently be retrieved and decoded by the Polykey Agent.
-4. Posting of the claim on the digital identity: The final step is for a copy of the claim (which has been signed by the claiming Keynode) to be published by the digital identity on the digital identity provider. After this step has been completed, there is a record of the cryptolink (known as an [Identity Proof](./Glossary.md#identity-proof)) both within Polykey (on the Keynode's Sigchain) and on the digital identity provider (in its record of statements made by the digital identity). This has the benefit of allowing augmentations to be visible to (and traceable by) both agents within Polykey (both human and machine) and the public.
+4. Posting of the claim on the digital identity: The final step is for a copy of the claim (which has been signed by the claiming Keynode) to be published by the digital identity on the digital identity provider. After this step has been completed, there is a record of the cryptolink (known as an [Identity Proof](./glossary.md#identity-proof)) both within Polykey (on the Keynode's Sigchain) and on the digital identity provider (in its record of statements made by the digital identity). This has the benefit of allowing augmentations to be visible to (and traceable by) both agents within Polykey (both human and machine) and the public.
 
 <p align="center">
   <figure>
@@ -140,13 +140,13 @@ The ACL is a record of the access permissions that you allow other agents to hav
 
 ### Gestalt Discovery
 
-While the ACL allows agents to control when, how, and who they share secrets with, it cannot help them make the judgments of trust necessary for this sharing to be authorized. This is where Polykey makes use of [discovery](./Glossary.md#discovery) to find and authenticate agents.
+While the ACL allows agents to control when, how, and who they share secrets with, it cannot help them make the judgments of trust necessary for this sharing to be authorized. This is where Polykey makes use of [discovery](./glossary.md#discovery) to find and authenticate agents.
 
 Recall the process for the formation of Gestalts; they are comprised of Keynodes, whose Sigchains store the cryptolink claims linking digital identities and other Keynodes into one entity. Keynodes can also store the names and locations of other Keynodes it knows, those both inside and outside of its Gestalt. As such, all Gestalts within Polykey can be connected to form a Gestalt Graph representing every user.
 
 As a decentralized network, there is no central directory of Keynodes or digital identities within Polykey that can be used to monitor and manage the Gestalt Graph. Instead, each individual Keynode acts as a single directory, contacting known Keynodes (and each of these Keynodes' known Keynodes) to traverse and discover the entire Gestalt Graph. This process allows us to find Gestalts, however, there are further steps we must take before we can authenticate these representations as agents and begin to share secrets with them.
 
-[Social Discovery](./Glossary.md#social-discovery) is Polykey's method of discovering agents you wish to share secrets with through digital identities. Because the augmentation process by which digital identities are claimed by Gestalt Keynodes involves publishing an Identity Proof on the claimed digital identity, digital identity providers can be systematically searched for these statements. Furthermore, since the Identity Proof must be signed by the claiming Keynode, its public key can be used to verify the authenticity of the claim, and its Sigchain can be searched for the corresponding cryptolink as an added measure of security.
+[Social Discovery](./glossary.md#social-discovery) is Polykey's method of discovering agents you wish to share secrets with through digital identities. Because the augmentation process by which digital identities are claimed by Gestalt Keynodes involves publishing an Identity Proof on the claimed digital identity, digital identity providers can be systematically searched for these statements. Furthermore, since the Identity Proof must be signed by the claiming Keynode, its public key can be used to verify the authenticity of the claim, and its Sigchain can be searched for the corresponding cryptolink as an added measure of security.
 
 Once we have found the Keynode claiming ownership of a particular digital identity, we can follow the cryptolink claims on its Sigchain to discover the rest of its Gestalt. In this way, it is possible to find other claimed digital identities on other providers, giving us more information that we can use in our decision of whether to trust the Gestalt or not. It is once we have made this decision that we can begin to share secret information because it is at this stage that we trust that the Gestalt is representative of the agent we wish to communicate with.
 

--- a/docs/theory/decentralized-trust-network.md
+++ b/docs/theory/decentralized-trust-network.md
@@ -57,7 +57,7 @@ Polykey's secrets are stored in [Vaults](./glossary.md#vault) that are managed a
 
 <p align="center">
   <figure>
-    <img src="images/divio_quadrant.png" width="100%" />
+    <img src="/images/divio_quadrant.png" width="100%" />
     <br />
     <figcaption>X.509 certificates act as the root of trust for Polykey Sigchains</figcaption>
   </figure>
@@ -78,7 +78,7 @@ Keynodes store secrets, digital identities are artifacts of the agent's identity
 
 <p align="center">
   <figure>
-    <img src="images/gestalts-and-DIs/GestaltDiagram.png" width="70%" />
+    <img src="/images/gestalts-and-DIs/GestaltDiagram.png" width="70%" />
     <br />
     <figcaption>Visual depiction of a Polykey Gestalt</figcaption>
   </figure>
@@ -96,7 +96,7 @@ Our augmentation process is what allows Polykey to utilize digital identities fo
 
 <p align="center">
   <figure>
-    <img src="images/gestalts-and-DIs/keybase.png" width="70%" />
+    <img src="/images/gestalts-and-DIs/keybase.png" width="70%" />
     <br />
     <figcaption>Digital identity augmentation as implemented within Keybase</figcaption>
   </figure>
@@ -110,7 +110,7 @@ The process of digital identity augmentation within Polykey involves four main s
 
 <p align="center">
   <figure>
-    <img src="images/gestalts-and-DIs/augmentation.png" width="90%" />
+    <img src="/images/gestalts-and-DIs/augmentation.png" width="90%" />
     <br />
     <figcaption>Polykey's Digital Identity (DI) augmentation process</figcaption>
   </figure>
@@ -118,7 +118,7 @@ The process of digital identity augmentation within Polykey involves four main s
 
 <p align="center">
   <figure>
-    <img src="images/gestalts-and-DIs/augmentationv3.png" width="90%" />
+    <img src="/images/gestalts-and-DIs/augmentationv3.png" width="90%" />
     <br />
     <figcaption>Structure of a cryptolink generated via augmentation</figcaption>
   </figure>
@@ -152,7 +152,7 @@ Once we have found the Keynode claiming ownership of a particular digital identi
 
 <p align="center">
   <figure>
-    <img src="images/gestalts-and-DIs/gestalt-discovery.png" width="90%" />
+    <img src="/images/gestalts-and-DIs/gestalt-discovery.png" width="90%" />
     <br />
     <figcaption>The Gestalt Discovery process</figcaption>
   </figure>
@@ -162,7 +162,7 @@ Because all of Polykey's Gestalts are connected, the trust between them forms a 
 
 <p align="center">
   <figure>
-    <img src="images/gestalts-and-DIs/gestalt-trust-chain.png" width="90%" />
+    <img src="/images/gestalts-and-DIs/gestalt-trust-chain.png" width="90%" />
     <br />
     <figcaption>The beginnings of a trust network formed by Gestalts</figcaption>
   </figure>

--- a/docs/theory/glossary.md
+++ b/docs/theory/glossary.md
@@ -8,7 +8,7 @@ Agent is any entity that possesses agency. That is the motivation and will to ac
 
 ### Augmentation
 
-The process of establishing a [cryptolink](./Glossary.md#cryptolink) between a [Keynode](./Glossary.md#keynode) and [digital identity](./Glossary.md#digital-identity), making a claim of ownership of the Keynode over the digital identity, and of the [agent](./Glossary.md#agent) who is represented by the digital identity over the Keynode.
+The process of establishing a [cryptolink](./glossary.md#cryptolink) between a [Keynode](./glossary.md#keynode) and [digital identity](./glossary.md#digital-identity), making a claim of ownership of the Keynode over the digital identity, and of the [agent](./glossary.md#agent) who is represented by the digital identity over the Keynode.
 
 ### Authenticity
 
@@ -16,27 +16,27 @@ The ability to check that the source of origin of a piece of data is correct.
 
 ### Cryptolink
 
-A statement of a [Keynode's](./Glossary.md#keynode) ownership over a [digital identity](./Glossary.md#digital-identity), or its relatedness to another Keynode.
+A statement of a [Keynode's](./glossary.md#keynode) ownership over a [digital identity](./glossary.md#digital-identity), or its relatedness to another Keynode.
 
 ### Digital identity
 
-Digital information that can be used to represent a physical [agent](./Glossary.md#agent) or entity. In the case of Polykey, digital identities are social media accounts existing on providers such as GitHub, Facebook, Instagram, and LinkedIn.
+Digital information that can be used to represent a physical [agent](./glossary.md#agent) or entity. In the case of Polykey, digital identities are social media accounts existing on providers such as GitHub, Facebook, Instagram, and LinkedIn.
 
 ### Discovery
 
-The process of systematically finding other Polykey users, represented by their [Gestalts](./Glossary.md#gestalt), as well as the components of the Gestalt.
+The process of systematically finding other Polykey users, represented by their [Gestalts](./glossary.md#gestalt), as well as the components of the Gestalt.
 
 ### Gestalt
 
-The representation of an [agent](./Glossary.md#agent) within Polykey. They combine [identity](./Glossary.md#identity) information from [digital identities](./Glossary.md#digital-identity) with Polykey [Keynodes](./Glossary.md#keynode).
+The representation of an [agent](./glossary.md#agent) within Polykey. They combine [identity](./glossary.md#identity) information from [digital identities](./glossary.md#digital-identity) with Polykey [Keynodes](./glossary.md#keynode).
 
 ### Identity
 
-Information about a specific [agent](./Glossary.md#agent), as well as its attributes, that uniquely distinguishes it from other agents within a particular context.
+Information about a specific [agent](./glossary.md#agent), as well as its attributes, that uniquely distinguishes it from other agents within a particular context.
 
 ### Identity Proof
 
-The claim existing on both a [Keynode's](./Glossary.md#keynode) [Sigchain](./Glossary.md#sigchain) and on a [digital identity](./Glossary.md#digital-identity) as proof of the existence of an [augmentation](./Glossary.md#augmentation) between them.
+The claim existing on both a [Keynode's](./glossary.md#keynode) [Sigchain](./glossary.md#sigchain) and on a [digital identity](./glossary.md#digital-identity) as proof of the existence of an [augmentation](./glossary.md#augmentation) between them.
 
 ### Integrity
 
@@ -44,11 +44,11 @@ The ability to check that a piece of data had not been mutated since its creatio
 
 ### Keynode
 
-Distributed nodes living on a user's computing device, identified by their own public and private key pair. Keynodes store and manage [Vaults](./Glossary.md#vault).
+Distributed nodes living on a user's computing device, identified by their own public and private key pair. Keynodes store and manage [Vaults](./glossary.md#vault).
 
 ### Point-of-presence
 
-A point of communication between two entities. For example, a [digital identity](./Glossary.md#digital-identity) is a point-of-presence between two [agents](./Glossary.md#agent), usually human, at which information pertaining to [identity](./Glossary.md#identity) can be exchanged.
+A point of communication between two entities. For example, a [digital identity](./glossary.md#digital-identity) is a point-of-presence between two [agents](./glossary.md#agent), usually human, at which information pertaining to [identity](./glossary.md#identity) can be exchanged.
 
 ### Resource
 
@@ -56,7 +56,7 @@ A resource is any digital object that can be interacted with. Usually a resource
 
 ### Sigchain
 
-A chain of signed statements stored on a [Keynode](./Glossary.md#keynode), documenting the claims it has made over [digital identities](./Glossary.md#digital-identity) and other Keynodes.
+A chain of signed statements stored on a [Keynode](./glossary.md#keynode), documenting the claims it has made over [digital identities](./glossary.md#digital-identity) and other Keynodes.
 
 ### Secret
 
@@ -75,8 +75,8 @@ In Polykey, we consider secrets that have extrinsic value, the currency of acces
 
 ### Social Discovery
 
-A form of [discovery](./Glossary.md#discovery) by which [Gestalts](./Glossary.md#gestalt) are discovered through [digital identities](./Glossary.md#digital-identity), rather than from within Polykey.
+A form of [discovery](./glossary.md#discovery) by which [Gestalts](./glossary.md#gestalt) are discovered through [digital identities](./glossary.md#digital-identity), rather than from within Polykey.
 
 ### Vault
 
-The base file structure used within Polykey to store [secrets](./Glossary.md#secret). Each Vault makes use of an encrypted file system to manage and share the secrets it contains.
+The base file structure used within Polykey to store [secrets](./glossary.md#secret). Each Vault makes use of an encrypted file system to manage and share the secrets it contains.

--- a/docs/theory/secrets-management.md
+++ b/docs/theory/secrets-management.md
@@ -2,9 +2,9 @@
 
 Today's digital landscape is a decentralized network of computing systems which includes web and mobile applications, micro-services, devices, Internet of Things and APIs (Application Programming Interfaces). Managing secret data is essential to the secure usage of this global network.
 
-To understand secrets management, we must first understand how [secrets](./Glossary.md#secret) are fundamental to the authentication and authorization of secure computing systems.
+To understand secrets management, we must first understand how [secrets](./glossary.md#secret) are fundamental to the authentication and authorization of secure computing systems.
 
-Authentication is a procedure for identifying an [agent](./Glossary.md#agent) attempting to access a particular [resource](./Glossary.md#resource), and to guarantee that only valid identities are allowed access to a resource. Authentication procedures are implemented as communication protocols between humans and machines, or between machines to other machines.
+Authentication is a procedure for identifying an [agent](./glossary.md#agent) attempting to access a particular [resource](./glossary.md#resource), and to guarantee that only valid identities are allowed access to a resource. Authentication procedures are implemented as communication protocols between humans and machines, or between machines to other machines.
 
 Authorization is a way of controlling access to resources after the agent is identified. The access to resources have many names including privileges, permissions, authorities or capabilities. Managing authorization means granting, revoking or tracking of privileges to identified agents. Authorization systems are implemented as data-models that assign privileges to agents and resources.
 

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -11,9 +11,9 @@ const darkCodeTheme = require('prism-react-renderer/themes/dracula');
 const remarkImageSrcWithRequire = (options) => {
   return (ast) => {
     visit(ast, 'jsx', (node) => {
-      const matches = node.value.match(/^(<img\s.*?src=)"(\s*\/.*?)"(.*)$/);
+      const matches = node.value.match(/^(.*)(<img\s.*?src=)"(\s*\/.*?)"(.*)$/s);
       if (matches != null) {
-        node.value = `${matches[1]}{require("${matches[2]}").default}${matches[3]}`;
+        node.value = `${matches[1]}${matches[2]}{require("${matches[3]}").default}${matches[4]}`;
       }
     });
   };


### PR DESCRIPTION
### Description
Some <img /> elements that were contained by larger Docusaurus AST chunks were not being matched by the regex within the `remarkImageSrcWithRequire` plugin. This caused image urls to be resolved incorrectly in markdown files. In response, the regex logic of the  `remarkImageSrcWithRequire` plugin has been amended to match more leniently.

On another note, hyperlinks to ./Glossary.md have been replaced with ./glossary.md, as Docusaurus' markdown hyperlinks are not case insensitive.


### Tasks

- [x] 1. Make Regex logic of `remarkImageSrcWithRequire` plugin to be more lenient.
- [x] 2. Replace relative <img /> src's with absolute paths.
- [x] 3. Replace all instances of ./Glossary.md with ./glossary.md 

### Final checklist


* [x] Domain specific tests
* [x] Full tests
* [x] Updated inline-comment documentation
* [x] Lint fixed
* [x] Squash and rebased
* [x] Sanity check the final build
