### PR TITLE
feature: switched to polykey.com domain

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -73,7 +73,7 @@ release:deployment:
   environment:
     name: 'production'
     deployment_tier: 'production'
-    url: 'https://polykey.io/docs'
+    url: 'https://polykey.com/docs'
   script:
     - echo 'Perform service deployment for production'
     - >

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 Documentation for Polykey. This uses GitHub wiki as a CMS. This wiki is mirrored to Gitlab at https://gitlab.com/MatrixAI/open-source/Polykey-Docs.
 
-GitLab builds the wiki via the CI/CD into static pages, rendering the markdown files and templates it within the branding of [polykey.io](https://polykey.io).
+GitLab builds the wiki via the CI/CD into static pages, rendering the markdown files and templates it within the branding of [polykey.com](https://polykey.com).
 
-The CI/CD pushes it to [polykey.io/docs](https://polykey.io/docs) which is hosted by Cloudflare's pages and worker system.
+The CI/CD pushes it to [polykey.com/docs](https://polykey.com/docs) which is hosted by Cloudflare's pages and worker system.
 
 ## Contributing
 

--- a/docs/reference/cli/bootstrapping.md
+++ b/docs/reference/cli/bootstrapping.md
@@ -118,17 +118,17 @@ It will also start an uTP server on `0.0.0.0:1314` over UDP for NAT traversal.
 It will also start an HTTP 1.1 server on `0.0.0.0:1315` for HTTP integration.
 
 All keynodes are preconfigured to trust and contact the bootstrap keynode
-`bootstrap.polykey.io`. This in the future will likely be load balanced via
+`bootstrap.polykey.com`. This in the future will likely be load balanced via
 both DNS load balancing and also TCP/UDP load balancing.
 
-The `bootstrap.polykey.io` is itself a Polykey keynode. This node is maintained
+The `bootstrap.polykey.com` is itself a Polykey keynode. This node is maintained
 by the official Polykey team. This nodes serves 3 duties:
 
 1. P2P DHT synchronisation to allow globally decentralised nodes to share their node table information
 2. STUN NAT traversal - to faciliate direct P2P connections between compatible nodes
 3. TURN Relay NAT traversal - to facilitate proxied P2P connections between incompatible nodes
 
-The first duty is the most important one. Without the `bootstrap.polykey.io`, it
+The first duty is the most important one. Without the `bootstrap.polykey.com`, it
 is not possible for nodes that are on separate subnets to discover each other.
 
 Users are able to run their own "bootstrap nodes". Corporate networks can run

--- a/docs/reference/nodes/node-discovery.md
+++ b/docs/reference/nodes/node-discovery.md
@@ -14,7 +14,7 @@ type NodeAddress = {
   port: number;
 } | {
   type: 'dns':
-  address: 'bootstrap.polykey.io';
+  address: 'bootstrap.polykey.com';
   port: number;
 };
 
@@ -65,7 +65,7 @@ type NodeTable = {
 
 When PK first begins. There will be 2 nodes in the `NodeTable`.
 
-It will be itself, and also the bootstrap node `bootstrap.polykey.io`.
+It will be itself, and also the bootstrap node `bootstrap.polykey.com`.
 
 If it is the bootstrap node, then it only has itself or OTHER bootstrap nodes.
 
@@ -75,7 +75,7 @@ Which means the source code has:
 
 1. The bootstrap node's NodeId
 2. The bootstrap node's certificate (which means it has the bootstrap node's public key)
-3. The bootstrap node's NodeAddress `bootstrap.polykey.io`
+3. The bootstrap node's NodeAddress `bootstrap.polykey.com`
 
 The current node (if it is not a bootstrap node), will need to generate it's own:
 
@@ -94,7 +94,7 @@ See NAT Busting.
 
 ## Discovery Techniques
 
-- Hardcoded Discovery - bootstrap.polykey.io
+- Hardcoded Discovery - bootstrap.polykey.com
 - Manual Discovery - the user submits a certficate to PK node, and the PK adds it to the node table (I actually also know the NodeAddress) (if i know the NodeCertificate and NodeAddress, then I can add it manually to the NodeTable)
 - Local Area Network Discovery - use multicast (not been tested (there is hardcoded port for this))
 - Wide Area Network Discovery - use the DHT + Kademlia (you are synchronising the DHT automatically via kademlia protocol)

--- a/docs/reference/workers/worker-api.md
+++ b/docs/reference/workers/worker-api.md
@@ -22,7 +22,7 @@ Given that it has a lifetime, it seems it should be part of async start and stop
 
 This does mean it becomes part of setter injection, and each other domain that checks whether it has access to the pool or not in order to perform the functionality.
 
-Using worker pools requires access to a "worker script". This worker script then exposes functions that you can run on the worker. We need to see how this would work in the case when electron uses webpack to bundle this up. We need to ensure the path lookup still works. So any "fs" paths should be careful here, just as how we had to deal with the bootstrap.polykey.io certificate paths.
+Using worker pools requires access to a "worker script". This worker script then exposes functions that you can run on the worker. We need to see how this would work in the case when electron uses webpack to bundle this up. We need to ensure the path lookup still works. So any "fs" paths should be careful here, just as how we had to deal with the bootstrap.polykey.com certificate paths.
 
 Because the worker script has to be a relative path to a file on disk in the built distribution. When using `Polykey` with webpack, you have to be careful to process the worker script paths.
 

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -26,7 +26,7 @@ const config = {
   title: "Polykey Documentation",
   tagline:
     "Documentation for Polykey - Tutorials, How-To Guides, Theory and Reference",
-  url: "https://polykey.io",
+  url: "https://polykey.com",
   baseUrl: "/docs/",
   onBrokenLinks: "warn",
   onBrokenMarkdownLinks: "warn",
@@ -75,13 +75,13 @@ const config = {
       },
       items: [
         {
-          to: "https://polykey.io/",
+          to: "https://polykey.com/",
           label: "Home",
           position: "right",
         },
-        { to: 'https://polykey.io/blog', label: 'Blog', position: 'right' },
+        { to: 'https://polykey.com/blog', label: 'Blog', position: 'right' },
         { to: 'pathname:///docs', label: 'Docs', position: 'right' },
-        { to: 'https://polykey.io/download', label: 'Download', position: 'right' },
+        { to: 'https://polykey.com/download', label: 'Download', position: 'right' },
         {
           href: "https://github.com/MatrixAI/Polykey-Docs",
           label: "GitHub",

--- a/server/index.ts
+++ b/server/index.ts
@@ -46,7 +46,7 @@ async function handleFetchEvent(event: FetchEvent): Promise<Response> {
 
 /**
  * Map request to documentation asset (HTML, CSS, JS, images, files... etc)
- * This worker is routed from `polykey.io/docs`
+ * This worker is routed from `polykey.com/docs`
  * All of the `../docs` assets is uploaded to the "root" of the worker
  * Therefore the `/docs` path segment must be removed, as `getAssetFromKV` uses the pathname
  * of the URL to look up the correct asset
@@ -55,7 +55,7 @@ function mapRequestToDocs(req: Request): Request {
   // Default mapping resolves directory URLs e.g. `/dir` becomes `/dir/index.html`
   const assetRequest = mapRequestToAsset(req);
   const assetUrl = new URL(assetRequest.url);
-  // Strip the `/docs` segment: `https://polykey.io/docs/...` -> `https://polykey.io/...`
+  // Strip the `/docs` segment: `https://polykey.com/docs/...` -> `https://polykey.com/...`
   assetUrl.pathname = assetUrl.pathname.replace(/^\/docs/, "/");
   return new Request(assetUrl.toString(), assetRequest);
 }

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -8,5 +8,5 @@ workers_dev = true
 
 [env.production]
   name = "polykey-docs"
-  routes = ["polykey.io/docs", "polykey.io/docs/*"]
+  routes = ["polykey.com/docs", "polykey.com/docs/*"]
   workers_dev = false


### PR DESCRIPTION
### Description
This MR replaces all mentions of polykey.io with polykey.com as part of the migration to polykey.com.

### Issues Fixed
<!-- List all issues fixed by this PR. -->
* Fixes #6 

### Tasks
<!-- 
  List all tasks to be done by this MR.
  If a task is no longer required, add a strikethrough (including the checkbox):
  - ~~[ ] 3. ...~~ - being completed in #...
-->
- [x] 1. Replace all instances of polykey.io with polykey.com in pages.
- [x] 2. Update DNS rules for everything to permanent (301) redirect to https://polykey.com
- [x] 3. Delete old `polykey-io` workers and associated worker routes.

### Final checklist
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

* [x] Domain specific tests
* [x] Full tests
* [x] Updated inline-comment documentation
* [x] Lint fixed
* [x] Squash and rebased
* [x] Sanity check the final build