### PR TITLE
Syntax highlighting for polykey cli commands

### DIFF
--- a/docs/tutorials/polykey-cli/managing-vaults.md
+++ b/docs/tutorials/polykey-cli/managing-vaults.md
@@ -8,7 +8,7 @@ Vaults in Polykey are secure containers where you can store and manage secrets l
 
 To create a new vault, use the following command:
 
-```bash
+```pkcli
 polykey vaults create <vaultName>
 ```
 
@@ -16,7 +16,7 @@ polykey vaults create <vaultName>
 
 Create a new vault named `myvault`:
 
-```bash
+```pkcli
 polykey vaults create myvault
 ```
 
@@ -30,7 +30,7 @@ Vault zUvPxC9aKNw94E1yR9dffzY created successfully
 
 To see all the vaults you have, use the list command. This provides a simple way to view all vault names and their identifiers.
 
-```bash
+```pkcli
 polykey vaults list
 ```
 
@@ -46,7 +46,7 @@ myvault-101        	zErezdpLocYs1VRZPV3wcqS
 
 If you need to remove a vault, you can delete it using the delete command:
 
-```bash
+```pkcli
 polykey vaults delete <vaultName>
 ```
 
@@ -54,7 +54,7 @@ polykey vaults delete <vaultName>
 
 Delete the vault named myvault:
 
-```bash
+```pkcli
 polykey vaults delete myvault
 ```
 
@@ -64,7 +64,7 @@ This operation does not produce output on successful execution, indicating the v
 
 Each vault maintains a version history which tracks changes over time. Use the log command to view the history of commits to a vault.
 
-```bash
+```pkcli
 polykey vaults log <vaultName>
 ```
 
@@ -72,7 +72,7 @@ polykey vaults log <vaultName>
 
 View the log for `my-software-project`:
 
-```bash
+```pkcli
 polykey vaults log my-software-project
 ```
 
@@ -93,7 +93,7 @@ message    "AWS_ACCESS_KEY_ID added\n"
 
 To change the name of an existing vault, use the rename command. This allows you to update the vault's name to something more descriptive or appropriate.
 
-```bash
+```pkcli
 polykey vaults rename <oldVaultName> <newVaultName>
 ```
 
@@ -101,13 +101,13 @@ polykey vaults rename <oldVaultName> <newVaultName>
 
 Rename `myvault-1` to `myvault-101`:
 
-```bash
+```pkcli
 polykey vaults rename myvault-1 myvault-101
 ```
 
 Confirm the rename by running:
 
-```bash
+```pkcli
 polykey vaults list
 ```
 
@@ -117,6 +117,6 @@ Managing vaults is a foundational skill in using Polykey effectively. This secti
 
 For a full list of vault commands and options, run:
 
-```bash
+```pkcli
 polykey vaults -h
 ```

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -4,10 +4,6 @@ import type { Options as PluginGTagOptions } from '@docusaurus/plugin-google-gta
 import type { Options as ThemeOptions } from '@docusaurus/theme-classic';
 import type { UserThemeConfig } from '@docusaurus/theme-common';
 import { visit } from 'unist-util-visit';
-import { themes as prismThemes } from 'prism-react-renderer';
-
-const lightCodeTheme = prismThemes.github;
-const darkCodeTheme = prismThemes.dracula;
 
 /**
  * Docusaurus does not process JSX `<img src ="...">` URLs
@@ -65,7 +61,8 @@ const pluginTheme: [string, ThemeOptions] = [
 
 const themeConfig: UserThemeConfig = {
   colorMode: {
-    disableSwitch: true,
+    defaultMode: 'dark',
+    // DisableSwitch: false,
   },
   navbar: {
     logo: {
@@ -215,7 +212,7 @@ const themeConfig: UserThemeConfig = {
   prism: {
     additionalLanguages: ['shell-session', 'bash'],
     theme: require('./src/css/custom-prism-theme.ts'),
-    darkTheme: darkCodeTheme,
+    darkTheme: require('./src/css/dark-custom-prism-theme.ts'),
   },
 };
 

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -213,9 +213,9 @@ const themeConfig: UserThemeConfig = {
     copyright: `Copyright © ${new Date().getFullYear()} Matrix AI`,
   },
   prism: {
-    theme: lightCodeTheme,
+    additionalLanguages: ['shell-session', 'bash'],
+    theme: require('./src/css/custom-prism-theme.ts'),
     darkTheme: darkCodeTheme,
-    additionalLanguages: ['shell-session'],
   },
 };
 

--- a/src/css/custom-prism-theme.ts
+++ b/src/css/custom-prism-theme.ts
@@ -3,7 +3,6 @@ import type { PrismTheme } from 'prism-react-renderer';
 // To see changes in development restart docusaurus
 
 const theme: PrismTheme = {
-  // Polykey cli commands are attributed the token.plain class
   plain: {
     color: '#F8F8F2',
     backgroundColor: '#282A36',

--- a/src/css/custom-prism-theme.ts
+++ b/src/css/custom-prism-theme.ts
@@ -1,0 +1,74 @@
+import type { PrismTheme } from 'prism-react-renderer';
+
+// To see changes in development restart docusaurus
+
+const theme: PrismTheme = {
+  // Polykey cli commands are attributed the token.plain class
+  plain: {
+    color: '#F8F8F2',
+    backgroundColor: '#282A36',
+  },
+  styles: [
+    {
+      types: ['prolog', 'constant', 'builtin'],
+      style: {
+        color: 'rgb(189, 147, 249)',
+      },
+    },
+    {
+      types: ['inserted', 'function'],
+      style: {
+        color: 'rgb(80, 250, 123)',
+      },
+    },
+    {
+      types: ['deleted'],
+      style: {
+        color: 'rgb(255, 85, 85)',
+      },
+    },
+    {
+      types: ['changed'],
+      style: {
+        color: 'rgb(255, 184, 108)',
+      },
+    },
+    {
+      types: ['punctuation', 'symbol'],
+      style: {
+        color: 'rgb(248, 248, 242)',
+      },
+    },
+    {
+      types: ['string', 'char', 'tag', 'selector'],
+      style: {
+        color: 'rgb(255, 121, 198)',
+      },
+    },
+    {
+      types: ['keyword', 'variable'],
+      style: {
+        color: 'rgb(80, 250, 123)',
+      },
+    },
+    {
+      types: ['command'],
+      style: {
+        color: 'rgb(167, 199, 231)',
+      },
+    },
+    {
+      types: ['comment'],
+      style: {
+        color: 'rgb(98, 114, 164)',
+      },
+    },
+    {
+      types: ['attr-name'],
+      style: {
+        color: 'rgb(241, 250, 140)',
+      },
+    },
+  ],
+};
+export default theme;

--- a/src/css/dark-custom-prism-theme.ts
+++ b/src/css/dark-custom-prism-theme.ts
@@ -1,0 +1,73 @@
+import type { PrismTheme } from 'prism-react-renderer';
+
+// To see changes in development restart docusaurus
+
+const theme: PrismTheme = {
+  plain: {
+    color: '#F8F8F2',
+    backgroundColor: '#282A36',
+  },
+  styles: [
+    {
+      types: ['prolog', 'constant', 'builtin'],
+      style: {
+        color: 'rgb(189, 147, 249)',
+      },
+    },
+    {
+      types: ['inserted', 'function'],
+      style: {
+        color: 'rgb(80, 250, 123)',
+      },
+    },
+    {
+      types: ['deleted'],
+      style: {
+        color: 'rgb(255, 85, 85)',
+      },
+    },
+    {
+      types: ['changed'],
+      style: {
+        color: 'rgb(255, 184, 108)',
+      },
+    },
+    {
+      types: ['punctuation', 'symbol'],
+      style: {
+        color: 'rgb(248, 248, 242)',
+      },
+    },
+    {
+      types: ['string', 'char', 'tag', 'selector'],
+      style: {
+        color: 'rgb(255, 121, 198)',
+      },
+    },
+    {
+      types: ['keyword', 'variable'],
+      style: {
+        color: 'rgb(80, 250, 123)',
+      },
+    },
+    {
+      types: ['command'],
+      style: {
+        color: 'rgb(0, 199, 231)',
+      },
+    },
+    {
+      types: ['comment'],
+      style: {
+        color: 'rgb(98, 114, 164)',
+      },
+    },
+    {
+      types: ['attr-name'],
+      style: {
+        color: 'rgb(241, 250, 140)',
+      },
+    },
+  ],
+};
+export default theme;

--- a/src/prism/custom-cli.js
+++ b/src/prism/custom-cli.js
@@ -1,0 +1,30 @@
+import { Prism } from 'prism-react-renderer';
+
+Prism.languages.pkcli = {
+  comment: {
+    pattern: /#.*/,
+    greedy: true,
+  },
+  keyword:
+    /\b(?:vaults|create|list|delete|log|rename|list|-h|secrets|get|update|stat)\b/,
+  command: {
+    pattern: /(^\s*|\s+)(polykey)(?=\s|$)/,
+    lookbehind: true,
+  },
+  parameter: {
+    pattern: /--?\w+/,
+    alias: 'operator',
+  },
+  string: {
+    pattern: /("|')(?:\\.|(?!\1)[^\\\r\n])*\1/,
+    greedy: true,
+  },
+  function: {
+    pattern: /\b\w+(?=\()/,
+    alias: 'function',
+  },
+  number: {
+    pattern: /\b\d+(?:\.\d+)?\b/,
+    alias: 'number',
+  },
+};

--- a/src/theme/prism-include-languages.js
+++ b/src/theme/prism-include-languages.js
@@ -1,0 +1,26 @@
+import siteConfig from '@generated/docusaurus.config';
+export default function prismIncludeLanguages(prismObject) {
+  const {
+    themeConfig: { prism },
+  } = siteConfig;
+  const { additionalLanguages } = prism;
+  // Prism components work on the Prism instance on the window, while prism-
+  // react-renderer uses its own Prism instance. We temporarily mount the
+  // instance onto window, import components to enhance it, then remove it to
+  // avoid polluting global namespace.
+  // You can mutate PrismObject: registering plugins, deleting languages... As
+  // long as you don't re-assign it
+  globalThis.Prism = prismObject;
+  additionalLanguages.forEach((lang) => {
+    if (lang === 'php') {
+      // eslint-disable-next-line global-require
+      require('prismjs/components/prism-markup-templating.js');
+    }
+
+    // eslint-disable-next-line global-require, import/no-dynamic-require
+    require(`prismjs/components/prism-${lang}`);
+  });
+  require('@site/src/prism/custom-cli.js');
+
+  delete globalThis.Prism;
+}


### PR DESCRIPTION
### Description
This pr is to allow polykey cli commands in the docs to have appropriate syntax highlighting. Furthermore to improve the syntax highlighting of codeblocks using the `sh` or `bash` language prefix.

The current documentation page showing the changes for polykey cli commands is  at `/docs/tutorials/polykey-cli/managing-vaults`. For any `sh/bash` code blocks they should have better syntax highlighting site wide. 

To enable polykey cli syntax highlighting replace code blocks starting with ` ```sh ` or ` ```bash` to ` ```pkcli`.

### Issues Fixed
* Fixes #102 

### Tasks
- [x] 1. Enable syntax highlighting for polykey cli commands
- [x] 2. Enable syntax highlighting for sh code blocks.

### Final checklist
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

* [x] Domain specific tests
* [x] Full tests
* [x] Updated inline-comment documentation
* [x] Lint fixed
* [ ] Squash and rebased
* [x] Sanity check the final build
