### PR TITLE
Feature docs landing revamp

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -97,7 +97,3 @@ As you deploy more Polykey agents, you can join existing gestalts.
 Your gestalt is how other users are able to share secrets with a trusted
 identity. Your identity is the sum of the reputation of all your digital
 identities that are part of the gestalt.
-
-## Comparison to other Tools
-
-TBD

--- a/docs/reference/architecture/encryption-algorithms.md
+++ b/docs/reference/architecture/encryption-algorithms.md
@@ -14,12 +14,16 @@ cryptographic algorithms for optimal security and performance.
 
 ### Symmetric Encryption
 
-- **AES-GCM (Advanced Encryption Standard - Galois/Counter Mode)**
-  - Used for encrypting data at rest and in transit.
-  - Provides both encryption and authentication in a single step.
-  - 256-bit key length for strong security.
-  - Resistant to padding oracle attacks due to its authenticated encryption
-    structure.
+-### Symmetric Encryption
+
+- **XChaCha20-Poly1305 (IETF)**  
+  - **Key Size:** 256 bits  
+  - **Nonce Size:** 192 bits  
+  - **MAC Size:** 128 bits  
+  - This extended 192-bit nonce allows random nonces to be safely used, reducing the risk of nonce reuse and making the encryption scheme misuse-resistant.  
+  - A stream cipher approach is employed, encrypting data per block with a fresh, random nonce each time.
+  - Polykey stores its persistent state in an encrypted database, protected by a “Data Encryption Key” (DEK). This DEK is **not** derived from the root key, so rotating the root key does **not** require re-encrypting the entire database.
+  - By combining encryption and authentication, XChaCha20-Poly1305 ensures both confidentiality and integrity of the stored data.
 
 ### Asymmetric Encryption
 

--- a/docs/reference/architecture/encryption-algorithms.md
+++ b/docs/reference/architecture/encryption-algorithms.md
@@ -22,7 +22,7 @@ cryptographic algorithms for optimal security and performance.
   - **MAC Size:** 128 bits  
   - This extended 192-bit nonce allows random nonces to be safely used, reducing the risk of nonce reuse and making the encryption scheme misuse-resistant.  
   - A stream cipher approach is employed, encrypting data per block with a fresh, random nonce each time.
-  - Polykey stores its persistent state in an encrypted database, protected by a “Data Encryption Key” (DEK). This DEK is **not** derived from the root key, so rotating the root key does **not** require re-encrypting the entire database.
+  - Polykey stores its persistent state in an encrypted database, protected by a “Data Encryption Key” (DEK). This DEK is not derived from the root key, so rotating the root key does not require re-encrypting the entire database.
   - By combining encryption and authentication, XChaCha20-Poly1305 ensures both confidentiality and integrity of the stored data.
 
 ### Asymmetric Encryption


### PR DESCRIPTION
### Description
This PR revamps the Polykey documentation home page (located under the "Getting Started" category) to improve its clarity and usefulness for new users. The changes include:
- Removing outdated or distracting elements (such as the divio system reference, which was removed in PK-Docs 1.0).
- Enhancing the high-level overview to better describe Polykey’s capabilities, including both the CLI and client library.
- Updating the encryption algorithms section: replacing the AES-GCM information with details on how Polykey now uses XChaCha20-Poly1305 for encryption.
- Structuring content into key sections such as introduction, quick start guide, documentation overview (Tutorials, How-To Guides, Theory, References), high-level use cases, and conclusion.

### Issues Fixed
* Fixes #96

### Tasks
- [] Remove unnecessary references (e.g., divio system mention) from the home page.
- [] Update the content and structure of the home page to include a high-level overview of Polykey, its capabilities, and relevant documentation sections.
- [] Update the encryption algorithm documentation to accurately reflect that Polykey uses XChaCha20-Poly1305 instead of AES-GCM.
- [ ] Gather additional team feedback and iterate on further enhancements as needed.

### Final checklist
* [ ] Domain specific tests
* [ ] Full tests
* [ ] Updated inline-comment documentation
* [ ] Lint fixed
* [ ] Squash and rebased
* [ ] Sanity check the final build